### PR TITLE
Fix to create a database from scratch (no seed db)

### DIFF
--- a/roles/oradb-manage-db/templates/dbca-create-db.rsp.12.2.0.1.j2
+++ b/roles/oradb-manage-db/templates/dbca-create-db.rsp.12.2.0.1.j2
@@ -234,7 +234,7 @@ nodelist={% for host in groups[hostgroup] -%} {{host.split('.')[0]}} {%- if not 
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
 {% if dbh.dbca_templatename is defined %}
-templateName={{ dbh.oracle_db_name }}_{{ dbh.dbca_templatename }}
+templateName={{ dbh.dbca_templatename }}
 {% else %}
 templateName={{dbca_templatename}}
 {% endif %}


### PR DESCRIPTION
the template did not work, when I needed to create a database with "CREATE DATABASE" instead of using a seed Database

giving dbca_templatename: New_Database.dbt gave an error, because it tried to find DBNAME_New_Database.dbt